### PR TITLE
fix thermostat entity name warning

### DIFF
--- a/custom_components/daikinone/climate.py
+++ b/custom_components/daikinone/climate.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
 
     entities = [
         DaikinOneThermostat(
-            ClimateEntityDescription(key=device.id, has_entity_name=True),
+            ClimateEntityDescription(key=device.id, name=None),
             data,
             device,
         )


### PR DESCRIPTION
An entities name should be explicitly set to `None` when adopting the device name. Fixes this warning:
```
WARNING (MainThread) [homeassistant.helpers.entity] Entity None (<class 'custom_components.daikinone.climate.DaikinOneThermostat'>) is implicitly using device name by not setting its name. Instead, the name should be set to None, please report it to the custom integration author.
```