### PR TITLE
add sensor for reversing valve and fix case where status is not reported

### DIFF
--- a/custom_components/daikinone/daikinone.py
+++ b/custom_components/daikinone/daikinone.py
@@ -61,6 +61,7 @@ class DaikinIndoorUnit(DaikinEquipment):
 class DaikinOutdoorUnitReversingValveStatus(Enum):
     OFF = 0
     ON = 1
+    UNKNOWN = 255
 
 
 @dataclass

--- a/custom_components/daikinone/sensor.py
+++ b/custom_components/daikinone/sensor.py
@@ -21,6 +21,7 @@ from custom_components.daikinone import DOMAIN, DaikinOneData
 from custom_components.daikinone.const import MANUFACTURER
 from custom_components.daikinone.daikinone import (
     DaikinDevice,
+    DaikinOutdoorUnitReversingValveStatus,
     DaikinThermostat,
     DaikinIndoorUnit,
     DaikinEquipment,
@@ -536,6 +537,22 @@ async def async_setup_entry(
                             attribute=lambda e: e.fan_motor_amps,
                         ),
                     ]
+
+                    # optional outdoor unit sensors
+                    if equipment.reversing_valve is not DaikinOutdoorUnitReversingValveStatus.UNKNOWN:
+                        entities.append(
+                            DaikinOneEquipmentSensor(
+                                description=SensorEntityDescription(
+                                    key="reversing_valve",
+                                    name="Reversing Valve",
+                                    has_entity_name=True,
+                                    device_class=SensorDeviceClass.ENUM,
+                                ),
+                                data=data,
+                                device=equipment,
+                                attribute=lambda e: e.reversing_valve.name.capitalize(),
+                            )
+                        )
 
                 case _:
                     log.warning(f"unexpected equipment: {equipment}")


### PR DESCRIPTION
It was reported in #11 that a Daikin Fit heat pump is not reporting a reversing valve status. Added `UNKNOWN` to the status enum to avoid a crash.

Also adds a sensor for the reversing valve if its status is being reported.

Closes #11