### PR TITLE
fix optimistic state updates and temp set when schedule active

### DIFF
--- a/custom_components/daikinone/daikinone.py
+++ b/custom_components/daikinone/daikinone.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 from datetime import timedelta
 from enum import Enum, auto
@@ -209,7 +210,7 @@ class DaikinOne:
         if cool:
             payload["cspHome"] = cool.celsius
         if override_schedule:
-            payload["schedOverride"] = True
+            payload["schedOverride"] = 1
 
         await self.__req(
             url=f"{DAIKIN_API_URL_DEVICE_DATA}/{thermostat_id}",
@@ -468,7 +469,7 @@ class DaikinOne:
                         await self.__refresh_token()
                         return await self.__req(url, method, body, retry=False)
 
-        raise DaikinServiceException(
-            f"Failed to send request to Daikin API: method={method} url={url} body={body}, response={response}",
-            status=response.status,
-        )
+                raise DaikinServiceException(
+                    f"Failed to send request to Daikin API: method={method} url={url} body={json.dumps(body)}, response_code={response.status} response_body={await response.text()}",
+                    status=response.status,
+                )


### PR DESCRIPTION
Fixes the `schedOverride` parameter when calling the API to update set points. Not sure what changed but the API does not accept `true`, need to be `1`.

Fixes optimistic updates now that the attributes are not being read directly from the thermostat object. We now apply the thermostat -> attribute mapping during the optimistic update so HA knows about the new values.

Fixes a bug when going from auto to heat or cool and back, where the old single target temp was taking precedence over the temperature range.