### PR TITLE
fix hacs HA version requirement

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Daikin One",
-  "homeassistant": "2024.2",
+  "homeassistant": "2024.2.0",
   "render_readme": true
 }


### PR DESCRIPTION
While I could not reproduce the install issue mention in #24 even on a fresh install, this needing to be a fully version string makes sense.

Ref #24 