### PR TITLE
use more unique entity uids for new config entries

### DIFF
--- a/custom_components/daikinone/config_flow.py
+++ b/custom_components/daikinone/config_flow.py
@@ -5,16 +5,17 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_OPTION_ENTITY_UID_SCHEMA_VERSION_KEY
 from .daikinone import DaikinOne, DaikinUserCredentials
 
 log = logging.getLogger(__name__)
 
 
-class DaikinSkyportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class DaikinOneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Daikin One config flow."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     @property
     def schema(self):
@@ -40,6 +41,8 @@ class DaikinSkyportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_EMAIL: email,
                         CONF_PASSWORD: password,
+                        # internal options
+                        CONF_OPTION_ENTITY_UID_SCHEMA_VERSION_KEY: 1,
                     },
                 )
 

--- a/custom_components/daikinone/const.py
+++ b/custom_components/daikinone/const.py
@@ -13,3 +13,5 @@ PLATFORMS = [
 ]
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
+
+CONF_OPTION_ENTITY_UID_SCHEMA_VERSION_KEY = "entity_uid_schema_version"

--- a/custom_components/daikinone/daikinone.py
+++ b/custom_components/daikinone/daikinone.py
@@ -256,8 +256,6 @@ class DaikinOne:
         if payload.data["ctSystemCapEmergencyHeat"]:
             capabilities.add(DaikinThermostatCapability.EMERGENCY_HEAT)
 
-        schedule = DaikinThermostatSchedule(enabled=payload.data["schedEnabled"])
-
         thermostat = DaikinThermostat(
             id=payload.id,
             location_id=payload.locationId,
@@ -268,7 +266,7 @@ class DaikinOne:
             capabilities=capabilities,
             mode=DaikinThermostatMode(payload.data["mode"]),
             status=DaikinThermostatStatus(payload.data["equipmentStatus"]),
-            schedule=schedule,
+            schedule=DaikinThermostatSchedule(enabled=payload.data["schedEnabled"]),
             indoor_temperature=Temperature.from_celsius(payload.data["tempIndoor"]),
             indoor_humidity=payload.data["humIndoor"],
             set_point_heat=Temperature.from_celsius(payload.data["hspActive"]),


### PR DESCRIPTION
Introduce a schema version for sensor entity unique IDs. Existing config entries will remain unchanged with the legacy ID format. New config entries will use the new format which will ensure entity uniqueness even in cases where multiple pieces of equipment has the same model/serial.

Ref #24 