### PR TITLE
use µg/m³ for ozone

### DIFF
--- a/custom_components/daikinone/daikinone.py
+++ b/custom_components/daikinone/daikinone.py
@@ -121,7 +121,8 @@ class DaikinOneAirQualitySensorOutdoor:
     aqi: int
     aqi_summary_level: DaikinOneAirQualitySensorSummaryLevel
     particles_microgram_m3: int
-    ozone_ppb: int
+    # even though the app displays ppb, the levels seem to be µg/m³ based on my local weather data
+    ozone_microgram_m3: int
 
 
 @dataclass
@@ -200,6 +201,8 @@ class DaikinThermostat(DaikinDevice):
     set_point_cool: Temperature
     set_point_cool_min: Temperature
     set_point_cool_max: Temperature
+    outdoor_temperature: Temperature
+    outdoor_humidity: int
     air_quality_outdoor: DaikinOneAirQualitySensorOutdoor | None
     air_quality_indoor: DaikinOneAirQualitySensorIndoor | None
     equipment: dict[str, DaikinEquipment]
@@ -336,6 +339,8 @@ class DaikinOne:
             set_point_cool=Temperature.from_celsius(payload.data["cspActive"]),
             set_point_cool_min=Temperature.from_celsius(payload.data["EquipProtocolMinCoolSetpoint"]),
             set_point_cool_max=Temperature.from_celsius(payload.data["EquipProtocolMaxCoolSetpoint"]),
+            outdoor_temperature=Temperature.from_celsius(payload.data["tempOutdoor"]),
+            outdoor_humidity=payload.data["humOutdoor"],
             air_quality_outdoor=self.__map_air_quality_outdoor(payload),
             air_quality_indoor=self.__map_air_quality_indoor(payload),
             equipment=self.__map_equipment(payload),
@@ -351,7 +356,7 @@ class DaikinOne:
             aqi=payload.data["aqOutdoorValue"],
             aqi_summary_level=payload.data["aqOutdoorLevel"],
             particles_microgram_m3=payload.data["aqOutdoorParticles"],
-            ozone_ppb=payload.data["aqOutdoorOzone"],
+            ozone_microgram_m3=payload.data["aqOutdoorOzone"],
         )
 
     def __map_air_quality_indoor(self, payload: DaikinDeviceDataResponse) -> DaikinOneAirQualitySensorIndoor | None:

--- a/custom_components/daikinone/sensor.py
+++ b/custom_components/daikinone/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfElectricCurrent,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_BILLION,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -148,12 +147,14 @@ async def async_setup_entry(
                         has_entity_name=True,
                         state_class=SensorStateClass.MEASUREMENT,
                         device_class=SensorDeviceClass.OZONE,
-                        native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
+                        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
                         icon="mdi:air-filter",
                     ),
                     data=data,
                     device=thermostat,
-                    attribute=lambda d: d.air_quality_outdoor.ozone_ppb if d.air_quality_outdoor is not None else None,
+                    attribute=lambda d: (
+                        d.air_quality_outdoor.ozone_microgram_m3 if d.air_quality_outdoor is not None else None
+                    ),
                 ),
             ]
 


### PR DESCRIPTION
Home Assistant only support `µg/m³` as a unit for ozone. So we are switching to that.

The app shows `ppb` next to the outdoor ozone level, however I suspect it is really µg/m³. The number from Daikin almost perfectly matched my local weather data for ozone in µg/m³. A proper conversion from ppb to µg/m³ is roughly a doubling, so seems more likely they are just showing it with the wrong unit in the app.