### PR TITLE
include raw data for all devices when downloading diagnostics for the config entry

### DIFF
--- a/custom_components/daikinone/daikinone.py
+++ b/custom_components/daikinone/daikinone.py
@@ -234,14 +234,13 @@ class DaikinOne:
     def __init__(self, creds: DaikinUserCredentials):
         self.creds = creds
 
-    async def get_raw_device_data(self, device_id: str) -> dict[str, Any] | None:
+    async def get_all_raw_device_data(self) -> list[dict[str, Any]]:
         """Get raw device data"""
-        try:
-            return await self.__req(f"{DAIKIN_API_URL_DEVICE_DATA}/{device_id}")
-        except DaikinServiceException as e:
-            if e.status == 400 or e.status == 404:
-                return None
-            raise
+        return await self.__req(DAIKIN_API_URL_DEVICE_DATA)
+
+    async def get_raw_device_data(self, device_id: str) -> dict[str, Any]:
+        """Get raw device data"""
+        return await self.__req(f"{DAIKIN_API_URL_DEVICE_DATA}/{device_id}")
 
     async def update(self) -> None:
         await self.__refresh_thermostats()

--- a/custom_components/daikinone/diagnostics.py
+++ b/custom_components/daikinone/diagnostics.py
@@ -11,7 +11,10 @@ log = logging.getLogger(__name__)
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
-    return {}
+    data: DaikinOneData = hass.data[DOMAIN]
+    raw = await data.daikin.get_all_raw_device_data()
+
+    return {"raw": raw}
 
 
 async def async_get_device_diagnostics(
@@ -21,7 +24,4 @@ async def async_get_device_diagnostics(
     device_id = next(i for i in device.identifiers if i[0] == DOMAIN)[1]
     raw = await data.daikin.get_raw_device_data(device_id)
 
-    if raw is not None:
-        return {"synthetic": False, "raw": raw}
-    else:
-        return {"synthetic": True}
+    return {"raw": raw}


### PR DESCRIPTION
Allows for easier debugging when multiple thermostats are involved.