### PR TITLE
fix: sanitize max-RPS and enum-wrapped fields

### DIFF
--- a/custom_components/daikinone/client/fields.py
+++ b/custom_components/daikinone/client/fields.py
@@ -83,6 +83,8 @@ F_OD_MODE = StringField("ctOutdoorMode")
 
 F_OD_COMPRESSOR_RUNTIME = RuntimeField("ctOutdoorCompressorRunTime")
 
+F_OD_HEAT_MAX_RPS = IntField("ctOutdoorHeatMaxRPS", Sentinel.U16)
+
 F_OD_COMPRESSOR_SPEED_TARGET = IntField("ctTargetCompressorspeed", Sentinel.U8)
 F_OD_COMPRESSOR_SPEED_CURRENT = IntField("ctCurrentCompressorRPS", Sentinel.U16)
 F_OD_FAN_TARGET_RPM = IntField("ctTargetODFanRPM", Sentinel.U8, 10)

--- a/custom_components/daikinone/client/mapping.py
+++ b/custom_components/daikinone/client/mapping.py
@@ -192,9 +192,8 @@ def _map_outdoor_unit(payload: DaikinDeviceDataResponse) -> DaikinOutdoorUnit | 
     eid = f"{model}-{serial}"
 
     # assume it can cool, and if it can also heat it should be a heat pump
-    name = "Condensing Unit"
-    if payload.data["ctOutdoorHeatMaxRPS"] != 0 and payload.data["ctOutdoorHeatMaxRPS"] != 65535:
-        name = "Heat Pump"
+    heat_max_rps = read(payload.data, f.F_OD_HEAT_MAX_RPS)
+    name = "Heat Pump" if heat_max_rps else "Condensing Unit"
 
     return DaikinOutdoorUnit(
         id=eid,

--- a/custom_components/daikinone/client/models.py
+++ b/custom_components/daikinone/client/models.py
@@ -48,11 +48,19 @@ class DaikinOutdoorUnitReversingValveStatus(Enum):
     ON = 1
     UNKNOWN = 255
 
+    @classmethod
+    def _missing_(cls, value: object) -> "DaikinOutdoorUnitReversingValveStatus":
+        return cls.UNKNOWN
+
 
 class DaikinOutdoorUnitHeaterStatus(Enum):
     OFF = 0
     ON = 1
     UNKNOWN = 255
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DaikinOutdoorUnitHeaterStatus":
+        return cls.UNKNOWN
 
 
 @dataclass
@@ -140,6 +148,11 @@ class DaikinThermostatMode(Enum):
     COOL = 2
     AUTO = 3
     AUX_HEAT = 4
+    UNKNOWN = 255
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DaikinThermostatMode":
+        return cls.UNKNOWN
 
 
 class DaikinThermostatStatus(Enum):
@@ -148,6 +161,11 @@ class DaikinThermostatStatus(Enum):
     HEATING = 3
     CIRCULATING_AIR = 4
     IDLE = 5
+    UNKNOWN = 255
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DaikinThermostatStatus":
+        return cls.UNKNOWN
 
 
 @dataclass
@@ -159,12 +177,22 @@ class DaikinThermostatFanMode(Enum):
     OFF = 0
     ALWAYS_ON = 1
     SCHEDULED = 2
+    UNKNOWN = 255
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DaikinThermostatFanMode":
+        return cls.UNKNOWN
 
 
 class DaikinThermostatFanSpeed(Enum):
     LOW = 0
     MEDIUM = 1
     HIGH = 2
+    UNKNOWN = 255
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DaikinThermostatFanSpeed":
+        return cls.UNKNOWN
 
 
 @dataclass

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -8,6 +8,12 @@ from custom_components.daikinone.client.models import (
     DaikinEEVCoil,
     DaikinIndoorUnit,
     DaikinOutdoorUnit,
+    DaikinOutdoorUnitHeaterStatus,
+    DaikinOutdoorUnitReversingValveStatus,
+    DaikinThermostatFanMode,
+    DaikinThermostatFanSpeed,
+    DaikinThermostatMode,
+    DaikinThermostatStatus,
     DaikinUserCredentials,
 )
 
@@ -290,3 +296,142 @@ class TestEquipmentSkippedOnInvalidIdentity:
         thermostat = daikin_client.get_thermostats()["device123"]
         unit = next(e for e in thermostat.equipment.values() if isinstance(e, DaikinIndoorUnit))
         assert unit.id == "AH-MODEL-AH-SERIAL"
+
+
+class TestOutdoorUnitName:
+    async def test_heat_pump_when_max_rps_positive(self, daikin_client: DaikinOne) -> None:
+        device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctOutdoorHeatMaxRPS": 100})
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        unit = next(
+            e
+            for e in daikin_client.get_thermostats()["device123"].equipment.values()
+            if isinstance(e, DaikinOutdoorUnit)
+        )
+        assert unit.name == "Heat Pump"
+
+    async def test_condensing_unit_when_max_rps_zero(self, daikin_client: DaikinOne) -> None:
+        device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctOutdoorHeatMaxRPS": 0})
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        unit = next(
+            e
+            for e in daikin_client.get_thermostats()["device123"].equipment.values()
+            if isinstance(e, DaikinOutdoorUnit)
+        )
+        assert unit.name == "Condensing Unit"
+
+    async def test_condensing_unit_when_max_rps_sentinel(self, daikin_client: DaikinOne) -> None:
+        # 65535 is the U16 sentinel returned during a thermostat reboot; previously this
+        # was checked inline in mapping, now it flows through read()
+        device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctOutdoorHeatMaxRPS": 65535})
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        unit = next(
+            e
+            for e in daikin_client.get_thermostats()["device123"].equipment.values()
+            if isinstance(e, DaikinOutdoorUnit)
+        )
+        assert unit.name == "Condensing Unit"
+
+
+class TestEnumSanitization:
+    """Enum-wrapped raw values would previously raise ValueError during reboot, crashing
+    the refresh. _missing_ now coerces unknown values to UNKNOWN so the mapping completes."""
+
+    async def test_thermostat_mode_sentinel_becomes_unknown(self, daikin_client: DaikinOne) -> None:
+        device_data = _make_device()
+        device_data["data"]["mode"] = 255
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        assert daikin_client.get_thermostats()["device123"].mode is DaikinThermostatMode.UNKNOWN
+
+    async def test_thermostat_status_sentinel_becomes_unknown(self, daikin_client: DaikinOne) -> None:
+        device_data = _make_device()
+        device_data["data"]["equipmentStatus"] = 255
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        assert daikin_client.get_thermostats()["device123"].status is DaikinThermostatStatus.UNKNOWN
+
+    async def test_thermostat_fan_mode_sentinel_becomes_unknown(self, daikin_client: DaikinOne) -> None:
+        device_data = _make_device()
+        device_data["data"]["fanCirculate"] = 255
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        assert (
+            daikin_client.get_thermostats()["device123"].fan_mode is DaikinThermostatFanMode.UNKNOWN
+        )
+
+    async def test_thermostat_fan_speed_sentinel_becomes_unknown(self, daikin_client: DaikinOne) -> None:
+        device_data = _make_device()
+        device_data["data"]["fanCirculateSpeed"] = 255
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        assert (
+            daikin_client.get_thermostats()["device123"].fan_speed is DaikinThermostatFanSpeed.UNKNOWN
+        )
+
+    async def test_thermostat_enum_unexpected_value_becomes_unknown(
+        self, daikin_client: DaikinOne
+    ) -> None:
+        device_data = _make_device()
+        device_data["data"]["mode"] = 99
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        assert daikin_client.get_thermostats()["device123"].mode is DaikinThermostatMode.UNKNOWN
+
+    async def test_outdoor_reversing_valve_unexpected_value_becomes_unknown(
+        self, daikin_client: DaikinOne
+    ) -> None:
+        device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctReversingValve": 42})
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        unit = next(
+            e
+            for e in daikin_client.get_thermostats()["device123"].equipment.values()
+            if isinstance(e, DaikinOutdoorUnit)
+        )
+        assert unit.reversing_valve is DaikinOutdoorUnitReversingValveStatus.UNKNOWN
+
+    async def test_outdoor_heater_unexpected_value_becomes_unknown(
+        self, daikin_client: DaikinOne
+    ) -> None:
+        device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctCrankCaseHeaterOnOff": 42})
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        unit = next(
+            e
+            for e in daikin_client.get_thermostats()["device123"].equipment.values()
+            if isinstance(e, DaikinOutdoorUnit)
+        )
+        assert unit.crank_case_heater is DaikinOutdoorUnitHeaterStatus.UNKNOWN


### PR DESCRIPTION
Follow up to #111 

- Add `F_OD_HEAT_MAX_RPS` to the field catalog and route `ctOutdoorHeatMaxRPS` through `read()` instead of the inline `0 / 65535` check.
- Add `UNKNOWN = 255` + `_missing_` fallback to `DaikinThermostatMode`, `DaikinThermostatStatus`, `DaikinThermostatFanMode`, and `DaikinThermostatFanSpeed` so sentinel/unexpected raw values coerce to `UNKNOWN` instead of raising `ValueError`.
- Add `_missing_` to `DaikinOutdoorUnitReversingValveStatus` and `DaikinOutdoorUnitHeaterStatus` so unrecognized values fall back to the existing `UNKNOWN` member.
- Tests covering each of the above.