### PR TITLE
fix: tolerate missing unit-type keys on P1/P2 mini-split payloads

### DIFF
--- a/custom_components/daikinone/client/fields.py
+++ b/custom_components/daikinone/client/fields.py
@@ -14,6 +14,7 @@ from custom_components.daikinone.client.wire import (
     Sentinel,
     StringField,
     TempField,
+    UnitTypeField,
 )
 
 
@@ -33,6 +34,8 @@ F_HUM_OUTDOOR = PercentField("humOutdoor")
 
 # --- Air handler field catalog ---
 
+F_AH_UNIT_TYPE = UnitTypeField("ctAHUnitType")
+
 # percent demands: uint8 encoded with 0.5 resolution
 F_AH_FAN_REQ_DEMAND = IntField("ctAHFanRequestedDemand", Sentinel.U8, 0.5)
 F_AH_FAN_CUR_DEMAND = IntField("ctAHFanCurrentDemandStatus", Sentinel.U8, 0.5)
@@ -49,6 +52,8 @@ F_AH_MODE = StringField("ctAHMode")
 
 
 # --- Furnace (IFC) field catalog ---
+
+F_IFC_UNIT_TYPE = UnitTypeField("ctIFCUnitType")
 
 F_IFC_FAN_REQ_DEMAND = IntField("ctIFCFanRequestedDemandPercent", Sentinel.U8, 0.5)
 F_IFC_FAN_CUR_DEMAND = IntField("ctIFCCurrentFanActualStatus", Sentinel.U8, 0.5)
@@ -74,6 +79,8 @@ F_INDOOR_POWER = FloatField("ctIndoorPower", Sentinel.U16, 0.1)
 
 
 # --- Outdoor unit field catalog ---
+
+F_OD_UNIT_TYPE = UnitTypeField("ctOutdoorUnitType")
 
 F_OD_MODEL = StringField("ctOutdoorModelNoCharacter1_15")
 F_OD_SERIAL = StringField("ctOutdoorSerialNoCharacter1_15")
@@ -115,6 +122,8 @@ F_OD_FAN_MOTOR_AMPS = FloatField("ctODFanMotorCurrent", Sentinel.U8, 0.1)
 
 
 # --- EEV coil field catalog ---
+
+F_COIL_UNIT_TYPE = UnitTypeField("ctCoilUnitType")
 
 F_EEV_SERIAL = StringField("ctCoilSerialNoCharacter1_15")
 F_EEV_FIRMWARE = StringField("ctCoilControlSoftwareVersion")

--- a/custom_components/daikinone/client/mapping.py
+++ b/custom_components/daikinone/client/mapping.py
@@ -108,7 +108,7 @@ def map_equipment(payload: DaikinDeviceDataResponse) -> dict[str, DaikinEquipmen
 
 
 def _map_air_handler(payload: DaikinDeviceDataResponse) -> DaikinIndoorUnit | None:
-    if payload.data["ctAHUnitType"] >= 255:
+    if not read(payload.data, f.F_AH_UNIT_TYPE):
         return None
 
     model = read(payload.data, f.F_AH_MODEL)
@@ -143,7 +143,7 @@ def _map_air_handler(payload: DaikinDeviceDataResponse) -> DaikinIndoorUnit | No
 
 
 def _map_furnace(payload: DaikinDeviceDataResponse) -> DaikinIndoorUnit | None:
-    if payload.data["ctIFCUnitType"] >= 255:
+    if not read(payload.data, f.F_IFC_UNIT_TYPE):
         return None
 
     model = read(payload.data, f.F_IFC_MODEL)
@@ -178,7 +178,7 @@ def _map_furnace(payload: DaikinDeviceDataResponse) -> DaikinIndoorUnit | None:
 
 
 def _map_outdoor_unit(payload: DaikinDeviceDataResponse) -> DaikinOutdoorUnit | None:
-    if payload.data["ctOutdoorUnitType"] >= 255:
+    if not read(payload.data, f.F_OD_UNIT_TYPE):
         return None
 
     model = read(payload.data, f.F_OD_MODEL)
@@ -234,7 +234,7 @@ def _map_outdoor_unit(payload: DaikinDeviceDataResponse) -> DaikinOutdoorUnit | 
 
 
 def _map_eev_coil(payload: DaikinDeviceDataResponse) -> DaikinEEVCoil | None:
-    if payload.data["ctCoilUnitType"] >= 255:
+    if not read(payload.data, f.F_COIL_UNIT_TYPE):
         return None
 
     serial = read(payload.data, f.F_EEV_SERIAL)

--- a/custom_components/daikinone/client/wire.py
+++ b/custom_components/daikinone/client/wire.py
@@ -115,6 +115,18 @@ class CelsiusField:
     max_c: float = 80
 
 
+@dataclass(frozen=True, slots=True)
+class UnitTypeField:
+    """Equipment unit-type presence flag.
+
+    Reads as True when the ``ct*UnitType`` key is present and not the U8 sentinel.
+    P1/P2 mini-split payloads omit these keys entirely, so a missing key also reads
+    as False (equipment not present).
+    """
+
+    key: str
+
+
 # --- Reader ---
 
 
@@ -132,9 +144,13 @@ def read(data: dict[str, Any], f: StringField) -> str | None: ...
 def read(data: dict[str, Any], f: PercentField) -> int | None: ...
 @overload
 def read(data: dict[str, Any], f: CelsiusField) -> Temperature | None: ...
+@overload
+def read(data: dict[str, Any], f: UnitTypeField) -> bool: ...
 
 
 def read(data: dict[str, Any], f: Any) -> Any:
+    if isinstance(f, UnitTypeField):
+        return data.get(f.key, Sentinel.U8) < Sentinel.U8
     value = data[f.key]
     if isinstance(f, IntField):
         return None if value == f.sentinel else round(value * f.scale)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -298,6 +298,42 @@ class TestEquipmentSkippedOnInvalidIdentity:
         assert unit.id == "AH-MODEL-AH-SERIAL"
 
 
+class TestEquipmentUnitTypeAbsent:
+    """P1/P2 mini-split payloads omit the ``ct*UnitType`` keys entirely; the mapping
+    must treat that as 'equipment not present' rather than KeyError-ing on setup."""
+
+    async def test_no_equipment_mapped_when_unit_type_keys_missing(
+        self, daikin_client: DaikinOne
+    ) -> None:
+        device_data = _make_device()
+        for key in ("ctAHUnitType", "ctIFCUnitType", "ctOutdoorUnitType", "ctCoilUnitType"):
+            del device_data["data"][key]
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        thermostat = daikin_client.get_thermostats()["device123"]
+        assert thermostat.equipment == {}
+
+    async def test_partial_unit_type_keys_gate_only_their_own_equipment(
+        self, daikin_client: DaikinOne
+    ) -> None:
+        device_data = _make_device(OUTDOOR_UNIT_DATA)
+        del device_data["data"]["ctAHUnitType"]
+        del device_data["data"]["ctIFCUnitType"]
+        del device_data["data"]["ctCoilUnitType"]
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        thermostat = daikin_client.get_thermostats()["device123"]
+        assert any(isinstance(e, DaikinOutdoorUnit) for e in thermostat.equipment.values())
+        assert not any(isinstance(e, DaikinIndoorUnit) for e in thermostat.equipment.values())
+        assert not any(isinstance(e, DaikinEEVCoil) for e in thermostat.equipment.values())
+
+
 class TestOutdoorUnitName:
     async def test_heat_pump_when_max_rps_positive(self, daikin_client: DaikinOne) -> None:
         device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctOutdoorHeatMaxRPS": 100})


### PR DESCRIPTION
## Summary

P1/P2 mini-split thermostat payloads (e.g. FDMQ / 4MXL setups from #38 and #82) omit the `ct*UnitType` keys entirely, so setup crashes with `KeyError: 'ctAHUnitType'` before any equipment can be mapped. This brings the presence check into the wire-protocol layer so a missing key is handled the same as the U8 sentinel.

- Add `UnitTypeField` to `wire.py`; `read()` returns `False` when the key is absent or matches the U8 sentinel, `True` otherwise
- Declare `F_AH_UNIT_TYPE` / `F_IFC_UNIT_TYPE` / `F_OD_UNIT_TYPE` / `F_COIL_UNIT_TYPE` in `fields.py`
- Replace the four raw `payload.data["ct*UnitType"] >= 255` guards in `mapping.py` with `read()` calls
- Test coverage for fully-absent and partial-absent unit-type keys

Note: this only prevents the setup crash. Mini-split systems still expose no equipment until a proper P1/P2 field catalog lands (tracked separately in #87).