### PR TITLE
fix: tolerate missing ctSystemCap* keys on thermostat payloads

### DIFF
--- a/custom_components/daikinone/client/mapping.py
+++ b/custom_components/daikinone/client/mapping.py
@@ -31,11 +31,11 @@ log = logging.getLogger(__name__)
 
 def map_thermostat(payload: DaikinDeviceDataResponse) -> DaikinThermostat:
     capabilities: set[DaikinThermostatCapability] = set()
-    if payload.data["ctSystemCapHeat"]:
+    if payload.data.get("ctSystemCapHeat"):
         capabilities.add(DaikinThermostatCapability.HEAT)
-    if payload.data["ctSystemCapCool"]:
+    if payload.data.get("ctSystemCapCool"):
         capabilities.add(DaikinThermostatCapability.COOL)
-    if payload.data["ctSystemCapEmergencyHeat"]:
+    if payload.data.get("ctSystemCapEmergencyHeat"):
         capabilities.add(DaikinThermostatCapability.EMERGENCY_HEAT)
 
     return DaikinThermostat(

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -334,6 +334,26 @@ class TestEquipmentUnitTypeAbsent:
         assert not any(isinstance(e, DaikinEEVCoil) for e in thermostat.equipment.values())
 
 
+class TestThermostatCapabilitiesAbsent:
+    """Some thermostat payloads omit the ``ctSystemCap*`` flags entirely; mapping
+    must treat missing keys as 'capability not advertised' rather than KeyError-ing
+    on setup."""
+
+    async def test_no_capabilities_when_cap_keys_missing(
+        self, daikin_client: DaikinOne
+    ) -> None:
+        device_data = _make_device()
+        for key in ("ctSystemCapHeat", "ctSystemCapCool", "ctSystemCapEmergencyHeat"):
+            del device_data["data"][key]
+
+        with patch.object(daikin_client._transport, "request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = [device_data]
+            await daikin_client.update()
+
+        thermostat = daikin_client.get_thermostats()["device123"]
+        assert thermostat.capabilities == set()
+
+
 class TestOutdoorUnitName:
     async def test_heat_pump_when_max_rps_positive(self, daikin_client: DaikinOne) -> None:
         device_data = _make_device({**OUTDOOR_UNIT_DATA, "ctOutdoorHeatMaxRPS": 100})


### PR DESCRIPTION
## Summary

- Fixes #89 — setup failed with `KeyError: 'ctSystemCapHeat'` when a thermostat payload omitted the `ctSystemCap*` capability flags.
- `map_thermostat` now reads the three `ctSystemCapHeat`/`Cool`/`EmergencyHeat` keys via `.get()`, treating missing keys as "capability not advertised".
- Added a mapping test that deletes all three keys and asserts setup succeeds with an empty capability set.