### PR TITLE
models: Support very unhealthy air quality

### DIFF
--- a/custom_components/daikinone/client/models.py
+++ b/custom_components/daikinone/client/models.py
@@ -106,6 +106,7 @@ class DaikinOneAirQualitySensorSummaryLevel(Enum):
     UNHEALTHY = 2
     # The app shows 3 as "Unhealthy" but with a red color instead of orange, so we will call it "Hazardous"
     HAZARDOUS = 3
+    VERY_UNHEALTHY = 4
 
 
 @dataclass


### PR DESCRIPTION
The API sometimes reports a value of 4 for air quality, which appears as "Very Unhealthy" on my thermostat. Without this change, the integration fails to fully configure when the value exceeds the allowable values for the enum.